### PR TITLE
chore(role:helm): Remove diff plugin deployed by kubernetes.core.helm…

### DIFF
--- a/roles/helm/tasks/main.yml
+++ b/roles/helm/tasks/main.yml
@@ -26,6 +26,12 @@
 
 - name: Install "helm-diff" plugin
   block:
+    # Note(okozachenko1203): Remove legacy plugin to avoid two plugins claim the same name.
+    - name: Remove Helm diff plugin installed by kubernetes.core.helm_plugin
+      kubernetes.core.helm_plugin:
+        plugin_name: diff
+        state: absent
+
     - name: Get Helm plugins dir
       ansible.builtin.command: helm env HELM_PLUGINS
       changed_when: false

--- a/roles/helm/tasks/main.yml
+++ b/roles/helm/tasks/main.yml
@@ -26,11 +26,6 @@
 
 - name: Install "helm-diff" plugin
   block:
-    # Note(okozachenko1203): Remove legacy plugin to avoid two plugins claim the same name.
-    - name: Remove Helm diff plugin installed by kubernetes.core.helm_plugin
-      kubernetes.core.helm_plugin:
-        plugin_name: diff
-        state: absent
 
     - name: Get Helm plugins dir
       ansible.builtin.command: helm env HELM_PLUGINS
@@ -42,6 +37,12 @@
         path: "{{ helm_plugins_path.stdout }}"
         state: directory
         mode: "0755"
+
+    # Note(okozachenko1203): Remove legacy plugin to avoid two plugins claim the same name.
+    - name: Remove Helm diff plugin installed by kubernetes.core.helm_plugin
+      ansible.builtin.file:
+        path: "{{ helm_plugins_path.stdout }}/helm-diff"
+        state: absent
 
     - name: Install plugin
       ansible.builtin.include_role: # noqa: var-naming[no-role-prefix]


### PR DESCRIPTION
…_plugin

When the plugin is installed in offline mode, the dir name is different from the one installed by helm cli.
This leads to the <Error: two plugins claim the same name>. To avoid this, we uninstall the diff plugin before install it from binary.

fix https://github.com/vexxhost/ansible-collection-kubernetes/issues/36