### PR TITLE
feat: deprecate kube-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 tests/output
+.DS_Store

--- a/roles/cilium/templates/values.yml.j2
+++ b/roles/cilium/templates/values.yml.j2
@@ -1,3 +1,5 @@
+k8sServiceHost: "{{ kubernetes_hostname }}"
+k8sServicePort: 6443
 image:
   repository: "{{ cilium_node_image | vexxhost.kubernetes.docker_image('name') }}"
   tag: "{{ cilium_node_image | vexxhost.kubernetes.docker_image('tag') }}"
@@ -20,3 +22,4 @@ operator:
 ipam:
   operator:
     clusterPoolIPv4PodCIDR: "{{ cilium_ipv4_cidr | default('10.0.0.0/8') }}"
+kubeProxyReplacement: "strict"

--- a/roles/kubernetes/tasks/bootstrap-cluster.yml
+++ b/roles/kubernetes/tasks/bootstrap-cluster.yml
@@ -49,6 +49,7 @@
   throttle: 1
   ansible.builtin.shell: |
     kubeadm init --config /etc/kubernetes/kubeadm.yaml --upload-certs \
+                 --skip-phases=addon/kube-proxy \
                  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests{% if kubernetes_allow_unsafe_swap %},Swap{% endif %}
   args:
     creates: /etc/kubernetes/admin.conf

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -54,3 +54,14 @@
         key: node-role.kubernetes.io/control-plane
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+
+- name: Remove kube-proxy
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: "{{ item }}"
+    namespace: kube-system
+    name: kube-proxy
+  with_items:
+    - DaemonSet
+    - ConfigMap


### PR DESCRIPTION
Partially related: https://github.com/vexxhost/atmosphere/issues/184
 
TL;DR: EL9, Fedora36+, newer versions of other distributions comes with `iptables` 1.8.8 (`nftable` only) when `kube-proxy` image relies on internal `iptables` 1.8.4 binaries. In such a situation rules created with older version are not fully compatible with newer version. Actually it’s a total mess.

https://github.com/kubernetes/minikube/issues/15573
https://github.com/kubernetes-sigs/iptables-wrappers/pull/3
https://github.com/kubernetes/kube-proxy/issues/23
https://kubernetes.io/blog/2022/09/07/iptables-chains-not-api/#use-case-iptables-mode
https://twitter.com/thockin/status/1171143481001009152

In my tests on EL9 suggested workaround with `iptables-legacy` (hacked iptables 1.8.8 package) did not give positive results. Cilium agents on kube worker nodes tries access https://10.96.0.1:443 without success.

We have cilium, eBPF and modern kernel versions - let's deprecate oldie kube-proxy.

https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/#kubeproxy-free