### PR TITLE
Use minimum dependancy versions in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,9 +8,9 @@ description: Ansible collection for deploying Kubernetes clusters
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.posix: 1.3.0
-  community.crypto: 2.2.3
-  community.general: 4.5.0
+  ansible.posix: ">=1.3.0"
+  community.crypto: ">=2.2.3"
+  community.general: ">=4.5.0"
   kubernetes.core: 2.3.2
 tags:
   - application


### PR DESCRIPTION
For general purpose dependancies (specifically not the k8s collection), allow any version greater than the one specified in galaxy.yml