### PR TITLE
Set subpath for coredns image repository

### DIFF
--- a/roles/kubernetes/templates/kubeadm.yaml.j2
+++ b/roles/kubernetes/templates/kubeadm.yaml.j2
@@ -47,6 +47,8 @@ kind: ClusterConfiguration
 controlPlaneEndpoint: "{{ kubernetes_hostname }}:6443"
 {% if kubernetes_image_repository not in ("registry.k8s.io", "k8s.gcr.io") %}
 imageRepository: "{{ kubernetes_image_repository }}"
+dns:
+  imageRepository: "{{ kubernetes_image_repository }}/coredns"
 {% endif %}
 apiServer:
   extraArgs:


### PR DESCRIPTION
fix #30

https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#custom-images
![image](https://github.com/vexxhost/ansible-collection-kubernetes/assets/53085803/081bbcc2-a4af-425f-92ad-e64b1b6fc0d3)
