### PR TITLE
Update galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ dependencies:
   community.crypto: ">=2.2.3"
   community.general: ">=4.5.0"
   kubernetes.core: ">=2.3.2"
-  vexxhost.containers: "1.0.2"
+  vexxhost.containers: "1.1.0"
 tags:
   - application
   - cloud


### PR DESCRIPTION
Current version in v-c-kubernetes is in conflict with the most recent release of v-c-containers and cannot be co-installed