### PR TITLE
fix: cert_manager helm chart path must be relative to the role location

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-cert_manager_helm_chart_path: "../../charts/cert-manager/"
+cert_manager_helm_chart_path: "{{ role_path }}/../../charts/cert-manager/"
 cert_manager_helm_chart_ref: /usr/local/src/cert-manager
 
 cert_manager_helm_release_name: cert-manager


### PR DESCRIPTION
This path must be relative to the role location within vexxhost.kubernetes or it will not be found when the role is run from a playbook in a different collection