### PR TITLE
fix: migrate kube api port to 6443 for all controlplane components

### DIFF
--- a/roles/kube_vip/tasks/main.yml
+++ b/roles/kube_vip/tasks/main.yml
@@ -28,9 +28,13 @@
 - name: Switch API server to run on port 6443
   ignore_errors: true
   ansible.builtin.replace:
-    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    path: "{{ item }}"
     regexp: "16443"
     replace: "6443"
+  loop:
+    - /etc/kubernetes/manifests/kube-apiserver.yaml
+    - /etc/kubernetes/controller-manager.conf
+    - /etc/kubernetes/scheduler.conf
   register: kube_vip_port_change
   failed_when: kube_vip_port_change.rc != 0 and kube_vip_port_change.rc != 257
   notify:


### PR DESCRIPTION
fix https://github.com/vexxhost/ansible-collection-kubernetes/issues/98
regression by https://github.com/vexxhost/ansible-collection-kubernetes/commit/551188dbd7a5dd2009134a7075f4ba4463375bdb