### PR TITLE
Use kubelet_hostname instead of inventory_hostname_short

### DIFF
--- a/molecule/cluster-upgrade/prepare.yml
+++ b/molecule/cluster-upgrade/prepare.yml
@@ -25,7 +25,7 @@
       delegate_to: "{{ groups['controllers'][0] }}"
       kubernetes.core.k8s_info:
         kind: Node
-        name: "{{ inventory_hostname_short }}"
+        name: "{{ kubelet_hostname }}"
         wait: true
         wait_condition:
           type: Ready

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -30,7 +30,7 @@
   throttle: 1
   vexxhost.kubernetes.kubeadm_upgrade_node:
     api_endpoint: "https://{{ kubernetes_hostname }}:6443"
-    node: "{{ inventory_hostname_short }}"
+    node: "{{ kubelet_hostname }}"
     version: "{{ kubernetes_version }}"
 
 - name: Set node selector for CoreDNS components


### PR DESCRIPTION
A recent commit introduced further cases of this, originally fixed in 5c08c72a944c2cc53f1eca09eecf7112b6805a53