### PR TITLE
fix: Check that resources are in kubeadm-config configmap before usin…

### DIFF
--- a/roles/kubernetes_upgrade_check/tasks/main.yml
+++ b/roles/kubernetes_upgrade_check/tasks/main.yml
@@ -23,7 +23,9 @@
   register: kubernetes_upgrade_check_kubeadm_config
 
 - name: Determine if we are jumping multiple versions
-  when: kubernetes_upgrade_check_kubeadm_config is not failed
+  when:
+    - kubernetes_upgrade_check_kubeadm_config is not failed
+    - kubernetes_upgrade_check_kubeadm_config.resources | length > 0
   block:
     - name: Parse the ClusterConfiguration
       run_once: true


### PR DESCRIPTION
…g them

In some conditions the k8s_info module can succeed but return an empty list of resources. This can happen when the api server is running but the kubeadm-config cm is missing, then the next tasks fail with undefined variables.

This patch extends the condition on the kubernetes version check to ensure that resources from kubeadm-config are present.