### PR TITLE
feat: replace kube-proxy with cni functionality

### DIFF
--- a/roles/cilium/defaults/main.yml
+++ b/roles/cilium/defaults/main.yml
@@ -7,3 +7,5 @@ cilium_helm_values: {}
 
 cilium_node_image: quay.io/cilium/cilium:v1.14.8@sha256:7fca3ba4b04af066e8b086b5c1a52e30f52db01ffc642e7db0a439514aed3ada
 cilium_operator_image: quay.io/cilium/operator-generic:v1.14.8@sha256:56d373c12483c09964a00a29246595917603a077a298aa90a98e4de32c86b7dc
+
+cilium_replace_kube_proxy: false

--- a/roles/cilium/templates/values.yml.j2
+++ b/roles/cilium/templates/values.yml.j2
@@ -21,4 +21,10 @@ ipam:
   operator:
     clusterPoolIPv4PodCIDRList:
       - "{{ cilium_ipv4_cidr | default('10.0.0.0/8') }}"
+{% if cilium_replace_kube_proxy %}
+k8sServiceHost: "{{ kubernetes_hostname }}"
+k8sServicePort: 6443
+kubeProxyReplacement: "true"
+kubeProxyReplacementHealthzBindAddr: "0.0.0.0:10256"
+{% endif %}
 upgradeCompatibility: "1.13"

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -43,3 +43,6 @@ kubernetes_coredns_node_selector:
 
 # Allow custom CA usage in the cluster
 kubernetes_allow_custom_ca: false
+
+# Do not use kube-proxy. Instead use/configure cni replacement.
+kubernetes_remove_kube_proxy: false

--- a/roles/kubernetes/tasks/bootstrap-cluster.yml
+++ b/roles/kubernetes/tasks/bootstrap-cluster.yml
@@ -102,6 +102,7 @@
   throttle: 1
   ansible.builtin.shell: |
     kubeadm init --config /etc/kubernetes/kubeadm.yaml --upload-certs \
+                 {% if kubernetes_remove_kube_proxy %}--skip-phases=addon/kube-proxy \{% endif %}
                  --ignore-preflight-errors=DirAvailable--etc-kubernetes-manifests{% if kubernetes_allow_unsafe_swap %},Swap{% endif %}
   args:
     creates: /etc/kubernetes/admin.conf

--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -55,6 +55,19 @@
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
 
+- name: Remove kube-proxy resources
+  run_once: true
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: "{{ item }}"
+    namespace: kube-system
+    name: kube-proxy
+  with_items:
+    - DaemonSet
+    - ConfigMap
+  when: kubernetes_remove_kube_proxy | bool
+
 - name: Upgrade if necessary
   when:
     - kubernetes_upgrade_check_upgrade_required is defined


### PR DESCRIPTION
Second try to get rid of kube-proxy for EL9 without legacy iptables. All info in a previous PR comments: https://github.com/vexxhost/ansible-collection-kubernetes/pull/48

Also I'm not sure where to put something like this: `cilium_replace_kube_proxy: "{{ kubernetes_remove_kube_proxy }}"`
