### PR TITLE
fix: install python3-cryptography (#117)

### DIFF
--- a/roles/kubernetes/tasks/control-plane.yml
+++ b/roles/kubernetes/tasks/control-plane.yml
@@ -39,7 +39,9 @@
 # TODO(fitbeard): Move common system packages from all roles to dedicated role.
 - name: Install PIP
   ansible.builtin.package:
-    name: python3-pip
+    name:
+      - python3-pip
+      - python3-cryptography
 
 - name: Install Kubernetes python package
   ansible.builtin.pip:


### PR DESCRIPTION
This package is required by module community.crypto.x509_certificate_info which is used in join-cluster.yml

Fixes #117