### PR TITLE
fix: make sure the upgrade  uses the pause image

### DIFF
--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -100,120 +100,120 @@ in `inventory/group_vars/kubernetes.yml` before running the steps below.
 
 === "Playbooks"
 
-  ``` bash
-  ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
-  ---
-  # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
-  # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
-  
-  - name: Upgrade all packages
-    hosts: "{{ kubernetes_group | default('all') }}"
-    become: true
-    roles:
-      - role: vexxhost.kubernetes.kubeadm
-        vars:
-          kubeadm_version: "{{ kubernetes_version }}"
-      - role: vexxhost.kubernetes.kubectl
-        vars:
-          kubectl_version: "{{ kubernetes_version }}"
-      - role: vexxhost.kubernetes.kubelet
-        vars:
-          kubelet_version: "{{ kubernetes_version }}"
-  
-  - name: Run the control plane upgrade
-    hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
-    become: true
-    tasks:
-      - name: Run "kubeadm upgrade plan"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade plan
-        when: ansible_play_hosts[0] == inventory_hostname
-  
-      - name: Run "kubeadm upgrade apply"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
-        when: ansible_play_hosts[0] == inventory_hostname
-  
-      - name: Run "kubeadm upgrade node" on other controllers
-        changed_when: false
-        throttle: 1
-        ansible.builtin.shell: kubeadm upgrade node
-        when: ansible_play_hosts[0] != inventory_hostname
-  
-  # TODO: upgrade CNI
-  
-  - name: Run the "kubelet" upgrade
-    hosts: "{{ kubernetes_group | default('all') }}"
-    become: true
-    tasks:
-      - name: Run "kubeadm upgrade node"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade node
-  
-      - name: Restart "kubelet"
-        ansible.builtin.service:
-          name: kubelet
-          state: restarted
-  END
-  ```
+    ``` bash
+    ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
+    ---
+    # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
+    # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
+
+    - name: Upgrade all packages
+      hosts: "{{ kubernetes_group | default('all') }}"
+      become: true
+      roles:
+        - role: vexxhost.kubernetes.kubeadm
+          vars:
+            kubeadm_version: "{{ kubernetes_version }}"
+        - role: vexxhost.kubernetes.kubectl
+          vars:
+            kubectl_version: "{{ kubernetes_version }}"
+        - role: vexxhost.kubernetes.kubelet
+          vars:
+            kubelet_version: "{{ kubernetes_version }}"
+
+    - name: Run the control plane upgrade
+      hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
+      become: true
+      tasks:
+        - name: Run "kubeadm upgrade plan"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade plan
+          when: ansible_play_hosts[0] == inventory_hostname
+
+        - name: Run "kubeadm upgrade apply"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
+          when: ansible_play_hosts[0] == inventory_hostname
+
+        - name: Run "kubeadm upgrade node" on other controllers
+          changed_when: false
+          throttle: 1
+          ansible.builtin.shell: kubeadm upgrade node
+          when: ansible_play_hosts[0] != inventory_hostname
+
+    # TODO: upgrade CNI
+
+    - name: Run the "kubelet" upgrade
+      hosts: "{{ kubernetes_group | default('all') }}"
+      become: true
+      tasks:
+        - name: Run "kubeadm upgrade node"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade node
+
+        - name: Restart "kubelet"
+          ansible.builtin.service:
+            name: kubelet
+            state: restarted
+    END
+    ```
 
 === "Atmosphere"
 
-  ``` bash
-  ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
-  ---
-  # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
-  # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
-  
-  - name: Upgrade all packages
-    hosts: "{{ kubernetes_group | default('all') }}"
-    become: true
-    roles:
-      - role: vexxhost.atmosphere.defaults
-      - role: vexxhost.kubernetes.kubeadm
-        vars:
-          kubeadm_version: "{{ kubernetes_version }}"
-      - role: vexxhost.kubernetes.kubectl
-        vars:
-          kubectl_version: "{{ kubernetes_version }}"
-      - role: vexxhost.kubernetes.kubelet
-        vars:
-          kubelet_version: "{{ kubernetes_version }}"
-          containerd_pause_image: "{{ atmosphere_images['pause'] }}"
-  
-  - name: Run the control plane upgrade
-    hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
-    become: true
-    tasks:
-      - name: Run "kubeadm upgrade plan"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade plan
-        when: ansible_play_hosts[0] == inventory_hostname
-  
-      - name: Run "kubeadm upgrade apply"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
-        when: ansible_play_hosts[0] == inventory_hostname
-  
-      - name: Run "kubeadm upgrade node" on other controllers
-        changed_when: false
-        throttle: 1
-        ansible.builtin.shell: kubeadm upgrade node
-        when: ansible_play_hosts[0] != inventory_hostname
-  
-  # TODO: upgrade CNI
-  
-  - name: Run the "kubelet" upgrade
-    hosts: "{{ kubernetes_group | default('all') }}"
-    become: true
-    tasks:
-      - name: Run "kubeadm upgrade node"
-        changed_when: false
-        ansible.builtin.shell: kubeadm upgrade node
-  
-      - name: Restart "kubelet"
-        ansible.builtin.service:
-          name: kubelet
-          state: restarted
-  END
-  ```
+    ``` bash
+    ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
+    ---
+    # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
+    # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
+
+    - name: Upgrade all packages
+      hosts: "{{ kubernetes_group | default('all') }}"
+      become: true
+      roles:
+        - role: vexxhost.atmosphere.defaults
+        - role: vexxhost.kubernetes.kubeadm
+          vars:
+            kubeadm_version: "{{ kubernetes_version }}"
+        - role: vexxhost.kubernetes.kubectl
+          vars:
+            kubectl_version: "{{ kubernetes_version }}"
+        - role: vexxhost.kubernetes.kubelet
+          vars:
+            kubelet_version: "{{ kubernetes_version }}"
+            containerd_pause_image: "{{ atmosphere_images['pause'] }}"
+
+    - name: Run the control plane upgrade
+      hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
+      become: true
+      tasks:
+        - name: Run "kubeadm upgrade plan"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade plan
+          when: ansible_play_hosts[0] == inventory_hostname
+
+        - name: Run "kubeadm upgrade apply"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
+          when: ansible_play_hosts[0] == inventory_hostname
+
+        - name: Run "kubeadm upgrade node" on other controllers
+          changed_when: false
+          throttle: 1
+          ansible.builtin.shell: kubeadm upgrade node
+          when: ansible_play_hosts[0] != inventory_hostname
+
+    # TODO: upgrade CNI
+
+    - name: Run the "kubelet" upgrade
+      hosts: "{{ kubernetes_group | default('all') }}"
+      become: true
+      tasks:
+        - name: Run "kubeadm upgrade node"
+          changed_when: false
+          ansible.builtin.shell: kubeadm upgrade node
+
+        - name: Restart "kubelet"
+          ansible.builtin.service:
+            name: kubelet
+            state: restarted
+    END
+    ```

--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -98,6 +98,67 @@ in `inventory/group_vars/kubernetes.yml` before running the steps below.
     this step on a test cluster and also on a single node before running it
     on the entire cluster.
 
+=== "Playbooks"
+
+``` bash
+ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
+---
+# helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
+# TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
+
+- name: Upgrade all packages
+  hosts: "{{ kubernetes_group | default('all') }}"
+  become: true
+  roles:
+    - role: vexxhost.kubernetes.kubeadm
+      vars:
+        kubeadm_version: "{{ kubernetes_version }}"
+    - role: vexxhost.kubernetes.kubectl
+      vars:
+        kubectl_version: "{{ kubernetes_version }}"
+    - role: vexxhost.kubernetes.kubelet
+      vars:
+        kubelet_version: "{{ kubernetes_version }}"
+
+- name: Run the control plane upgrade
+  hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
+  become: true
+  tasks:
+    - name: Run "kubeadm upgrade plan"
+      changed_when: false
+      ansible.builtin.shell: kubeadm upgrade plan
+      when: ansible_play_hosts[0] == inventory_hostname
+
+    - name: Run "kubeadm upgrade apply"
+      changed_when: false
+      ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
+      when: ansible_play_hosts[0] == inventory_hostname
+
+    - name: Run "kubeadm upgrade node" on other controllers
+      changed_when: false
+      throttle: 1
+      ansible.builtin.shell: kubeadm upgrade node
+      when: ansible_play_hosts[0] != inventory_hostname
+
+# TODO: upgrade CNI
+
+- name: Run the "kubelet" upgrade
+  hosts: "{{ kubernetes_group | default('all') }}"
+  become: true
+  tasks:
+    - name: Run "kubeadm upgrade node"
+      changed_when: false
+      ansible.builtin.shell: kubeadm upgrade node
+
+    - name: Restart "kubelet"
+      ansible.builtin.service:
+        name: kubelet
+        state: restarted
+END
+```
+
+=== "Atmosphere"
+
 ``` bash
 ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
 ---

--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -108,6 +108,7 @@ ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
   hosts: "{{ kubernetes_group | default('all') }}"
   become: true
   roles:
+    - role: vexxhost.atmosphere.defaults
     - role: vexxhost.kubernetes.kubeadm
       vars:
         kubeadm_version: "{{ kubernetes_version }}"
@@ -117,6 +118,7 @@ ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
     - role: vexxhost.kubernetes.kubelet
       vars:
         kubelet_version: "{{ kubernetes_version }}"
+        containerd_pause_image: "{{ atmosphere_images['pause'] }}"
 
 - name: Run the control plane upgrade
   hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"

--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -100,120 +100,120 @@ in `inventory/group_vars/kubernetes.yml` before running the steps below.
 
 === "Playbooks"
 
-``` bash
-ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
----
-# helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
-# TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
-
-- name: Upgrade all packages
-  hosts: "{{ kubernetes_group | default('all') }}"
-  become: true
-  roles:
-    - role: vexxhost.kubernetes.kubeadm
-      vars:
-        kubeadm_version: "{{ kubernetes_version }}"
-    - role: vexxhost.kubernetes.kubectl
-      vars:
-        kubectl_version: "{{ kubernetes_version }}"
-    - role: vexxhost.kubernetes.kubelet
-      vars:
-        kubelet_version: "{{ kubernetes_version }}"
-
-- name: Run the control plane upgrade
-  hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
-  become: true
-  tasks:
-    - name: Run "kubeadm upgrade plan"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade plan
-      when: ansible_play_hosts[0] == inventory_hostname
-
-    - name: Run "kubeadm upgrade apply"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
-      when: ansible_play_hosts[0] == inventory_hostname
-
-    - name: Run "kubeadm upgrade node" on other controllers
-      changed_when: false
-      throttle: 1
-      ansible.builtin.shell: kubeadm upgrade node
-      when: ansible_play_hosts[0] != inventory_hostname
-
-# TODO: upgrade CNI
-
-- name: Run the "kubelet" upgrade
-  hosts: "{{ kubernetes_group | default('all') }}"
-  become: true
-  tasks:
-    - name: Run "kubeadm upgrade node"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade node
-
-    - name: Restart "kubelet"
-      ansible.builtin.service:
-        name: kubelet
-        state: restarted
-END
-```
+  ``` bash
+  ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
+  ---
+  # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
+  # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
+  
+  - name: Upgrade all packages
+    hosts: "{{ kubernetes_group | default('all') }}"
+    become: true
+    roles:
+      - role: vexxhost.kubernetes.kubeadm
+        vars:
+          kubeadm_version: "{{ kubernetes_version }}"
+      - role: vexxhost.kubernetes.kubectl
+        vars:
+          kubectl_version: "{{ kubernetes_version }}"
+      - role: vexxhost.kubernetes.kubelet
+        vars:
+          kubelet_version: "{{ kubernetes_version }}"
+  
+  - name: Run the control plane upgrade
+    hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
+    become: true
+    tasks:
+      - name: Run "kubeadm upgrade plan"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade plan
+        when: ansible_play_hosts[0] == inventory_hostname
+  
+      - name: Run "kubeadm upgrade apply"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
+        when: ansible_play_hosts[0] == inventory_hostname
+  
+      - name: Run "kubeadm upgrade node" on other controllers
+        changed_when: false
+        throttle: 1
+        ansible.builtin.shell: kubeadm upgrade node
+        when: ansible_play_hosts[0] != inventory_hostname
+  
+  # TODO: upgrade CNI
+  
+  - name: Run the "kubelet" upgrade
+    hosts: "{{ kubernetes_group | default('all') }}"
+    become: true
+    tasks:
+      - name: Run "kubeadm upgrade node"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade node
+  
+      - name: Restart "kubelet"
+        ansible.builtin.service:
+          name: kubelet
+          state: restarted
+  END
+  ```
 
 === "Atmosphere"
 
-``` bash
-ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
----
-# helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
-# TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
-
-- name: Upgrade all packages
-  hosts: "{{ kubernetes_group | default('all') }}"
-  become: true
-  roles:
-    - role: vexxhost.atmosphere.defaults
-    - role: vexxhost.kubernetes.kubeadm
-      vars:
-        kubeadm_version: "{{ kubernetes_version }}"
-    - role: vexxhost.kubernetes.kubectl
-      vars:
-        kubectl_version: "{{ kubernetes_version }}"
-    - role: vexxhost.kubernetes.kubelet
-      vars:
-        kubelet_version: "{{ kubernetes_version }}"
-        containerd_pause_image: "{{ atmosphere_images['pause'] }}"
-
-- name: Run the control plane upgrade
-  hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
-  become: true
-  tasks:
-    - name: Run "kubeadm upgrade plan"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade plan
-      when: ansible_play_hosts[0] == inventory_hostname
-
-    - name: Run "kubeadm upgrade apply"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
-      when: ansible_play_hosts[0] == inventory_hostname
-
-    - name: Run "kubeadm upgrade node" on other controllers
-      changed_when: false
-      throttle: 1
-      ansible.builtin.shell: kubeadm upgrade node
-      when: ansible_play_hosts[0] != inventory_hostname
-
-# TODO: upgrade CNI
-
-- name: Run the "kubelet" upgrade
-  hosts: "{{ kubernetes_group | default('all') }}"
-  become: true
-  tasks:
-    - name: Run "kubeadm upgrade node"
-      changed_when: false
-      ansible.builtin.shell: kubeadm upgrade node
-
-    - name: Restart "kubelet"
-      ansible.builtin.service:
-        name: kubelet
-        state: restarted
-END
-```
+  ``` bash
+  ansible-playbook -i inventory/hosts.ini /dev/stdin <<END
+  ---
+  # helm upgrade --values /tmp/mariadb.yml mariadb openstack-helm-infra/mariadb
+  # TODO: fix https://github.com/kubernetes/ingress-nginx/blob/712e10d4176da06e28a11eb6f9e2d7a263b887cb/rootfs/etc/nginx/template/nginx.tmpl#L1322
+  
+  - name: Upgrade all packages
+    hosts: "{{ kubernetes_group | default('all') }}"
+    become: true
+    roles:
+      - role: vexxhost.atmosphere.defaults
+      - role: vexxhost.kubernetes.kubeadm
+        vars:
+          kubeadm_version: "{{ kubernetes_version }}"
+      - role: vexxhost.kubernetes.kubectl
+        vars:
+          kubectl_version: "{{ kubernetes_version }}"
+      - role: vexxhost.kubernetes.kubelet
+        vars:
+          kubelet_version: "{{ kubernetes_version }}"
+          containerd_pause_image: "{{ atmosphere_images['pause'] }}"
+  
+  - name: Run the control plane upgrade
+    hosts: "{{ kubernetes_control_plane_group | default('controllers') }}"
+    become: true
+    tasks:
+      - name: Run "kubeadm upgrade plan"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade plan
+        when: ansible_play_hosts[0] == inventory_hostname
+  
+      - name: Run "kubeadm upgrade apply"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade apply v{{ kubernetes_version }} --yes
+        when: ansible_play_hosts[0] == inventory_hostname
+  
+      - name: Run "kubeadm upgrade node" on other controllers
+        changed_when: false
+        throttle: 1
+        ansible.builtin.shell: kubeadm upgrade node
+        when: ansible_play_hosts[0] != inventory_hostname
+  
+  # TODO: upgrade CNI
+  
+  - name: Run the "kubelet" upgrade
+    hosts: "{{ kubernetes_group | default('all') }}"
+    become: true
+    tasks:
+      - name: Run "kubeadm upgrade node"
+        changed_when: false
+        ansible.builtin.shell: kubeadm upgrade node
+  
+      - name: Restart "kubelet"
+        ansible.builtin.service:
+          name: kubelet
+          state: restarted
+  END
+  ```


### PR DESCRIPTION
When doing a k8s upgrade in a isolated env, kubelet role has a requirement to the containerd role.

This containerd role generates a config file. In this config file it has a config setting where to find the sandbox image.