### PR TITLE
Use include_tasks to respect group_vars

### DIFF
--- a/roles/upload_helm_chart/tasks/main.yml
+++ b/roles/upload_helm_chart/tasks/main.yml
@@ -1,2 +1,2 @@
-- name: Import help chart upload method tasks
-  ansible.builtin.import_tasks: "{{ upload_helm_chart_method }}.yml"
+- name: Include help chart upload method tasks
+  ansible.builtin.include_tasks: "{{ upload_helm_chart_method }}.yml"


### PR DESCRIPTION
With import_tasks all imports are processed very early, where some
variables, like group_vars might not be yet processed.

So if upload_helm_chart_method is defined in group_vars rather then
extra vars, value will be ignored and role will proceed with it's
defaults. Include in it's turn is more dynamic and will respect
group_vars.