### PR TITLE
[ATMOSPHERE-287] Add support for currently supported k8s versions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -31,6 +31,8 @@ jobs:
           - 1.26.15
           - 1.27.16
           - 1.28.13
+          - 1.29.12
+          - 1.30.8
         distro:
           - rockylinux9
           - ubuntu2004
@@ -72,6 +74,10 @@ jobs:
             version: 1.27.16
           - old_version: 1.27.16
             version: 1.28.13
+          - old_version: 1.28.13
+            version: 1.29.12
+          - old_version: 1.29.12
+            version: 1.30.8
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/roles/kube_vip/defaults/main.yml
+++ b/roles/kube_vip/defaults/main.yml
@@ -12,6 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Inventory group containing controllers
+kube_vip_control_plane_group: "{{ kubernetes_control_plane_group | default('controllers') }}"
+
 # Image to use for kube-vip
 kube_vip_image: ghcr.io/kube-vip/kube-vip:v0.6.4
 

--- a/roles/kube_vip/tasks/main.yml
+++ b/roles/kube_vip/tasks/main.yml
@@ -40,6 +40,32 @@
   notify:
     - Restart "kubelet" service
 
+- name: Check if super-admin.conf exists
+  ansible.builtin.stat:
+    path: /etc/kubernetes/super-admin.conf
+  failed_when: false
+  changed_when: false
+  register: kube_vip_stat_super_admin
+
+- name: Check if kubeadm has already run
+  ansible.builtin.stat:
+    path: /var/lib/kubelet/config.yaml
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  register: kube_vip_stat_kubelet_config
+
+- name: Set fact with KUBECONFIG path
+  ansible.builtin.set_fact:
+    kube_vip_kubeconfig_path: /etc/kubernetes/admin.conf
+
+- name: Set fact with KUBECONFIG path (with super-admin.conf)
+  ansible.builtin.set_fact:
+    kube_vip_kubeconfig_path: /etc/kubernetes/super-admin.conf
+  when:
+    - inventory_hostname == groups[kube_vip_control_plane_group] | first
+    - (kube_vip_stat_super_admin.stat.exists and kube_vip_stat_super_admin.stat.isreg) or (not kube_vip_stat_kubelet_config.stat.exists)
+
 - name: Upload Kubernetes manifest
   ansible.builtin.template:
     src: kube-vip.yaml.j2
@@ -47,6 +73,7 @@
     owner: root
     group: root
     mode: "0644"
+  changed_when: false
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers

--- a/roles/kube_vip/templates/kube-vip.yaml.j2
+++ b/roles/kube_vip/templates/kube-vip.yaml.j2
@@ -59,6 +59,10 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: /etc/kubernetes/admin.conf
+{% if kubernetes_version is ansible.builtin.version('1.28.14', '<') %}
+      path: "/etc/kubernetes/admin.conf"
+{% else %}
+      path: "{{ kube_vip_kubeconfig_path }}"
+{% endif %}
     name: kubeconfig
 status: {}

--- a/roles/kubeadm/defaults/main.yml
+++ b/roles/kubeadm/defaults/main.yml
@@ -30,6 +30,8 @@ kubeadm_checksums:
     1.27.16: 33622018f83515331ac70c2041eba5d814a6d78a40b8869f089ea502f63a1421
     1.28.4: b4d2531b7cddf782f59555436bc098485b5fa6c05afccdeecf0d62d21d84f5bd
     1.28.13: f23e9586811312998bc5e8847f6df52fc04809aed8c2c2fd750f2c42b3f87192
+    1.29.12: bce712631bc425726b45930e58b00790c2ab3deec4282f86af353ea907817c46
+    1.30.8: ffe1a2b6345fae55e059afe7eed90ae9f46f0a755fde5fc17b9113134ab8b79e
   arm64:
     1.19.16: f72db475c7a52deaab3ac04ee66e2c99dc4dc50b4fa85faf34ff319de869e1d6
     1.20.15: 76e132da8185a7c33e6178348d05570a1f78878d5e118c7402c9ad02e8b6fb77
@@ -47,8 +49,10 @@ kubeadm_checksums:
     1.27.16: 39fb88ab0f6b943bbe61dde5d7ea58ce728045a0556f9b6f56d66fe1f20affcc
     1.28.4: a4422780020954436b8e76ab1c59b68c5581a54432dd3e566c4709bb40c8d4f9
     1.28.13: 989630fb0de6fe750c6ee25ee01b72654a3087434ff488ff8fddedd0278720cc
+    1.29.12: d953ed504c2ddd08272d45cc94439fc69b7ffd77ff1d0c78917b3275a5c9c044
+    1.30.8: 7bca884b54e2c3988e81250f8eba6a49d718994dd7fe67d14905cb65dcec8b56
 
-kubeadm_download_url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubeadm_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubeadm" # noqa: yaml[line-length]
+kubeadm_download_url: "https://cdn.dl.k8s.io/release/v{{ kubeadm_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubeadm" # noqa: yaml[line-length]
 kubeadm_download_dest: /usr/bin/kubeadm
 kubeadm_binary_checksum: "{{ kubeadm_checksums[download_artifact_goarch][kubeadm_version] }}"
 

--- a/roles/kubectl/defaults/main.yml
+++ b/roles/kubectl/defaults/main.yml
@@ -30,6 +30,8 @@ kubectl_checksums:
     1.27.16: 97ea7cd771d0c6e3332614668a40d2c5996f0053ff11b44b198ea84dba0818cb
     1.28.4: 893c92053adea6edbbd4e959c871f5c21edce416988f968bec565d115383f7b8
     1.28.13: d7d363dd5a4c95444329bc5239b8718ebe84a043052958b2f15ee2feef9a28c6
+    1.29.12: 35fc028853e6f5299a53f22ab58273ea2d882c0f261ead0a2eed5b844b12dbfb
+    1.30.8: 7f39bdcf768ce4b8c1428894c70c49c8b4d2eee52f3606eb02f5f7d10f66d692
   arm64:
     1.19.16: 6ad55694db34b9ffbc3cb41761a50160eea0a962eb86899410593931b4e602d0
     1.20.15: d479febfb2e967bd86240b5c0b841e40e39e1ef610afd6f224281a23318c13dc
@@ -47,8 +49,10 @@ kubectl_checksums:
     1.27.16: 2f50cb29d73f696ffb57437d3e2c95b22c54f019de1dba19e2b834e0b4501eb9
     1.28.4: edf1e17b41891ec15d59dd3cc62bcd2cdce4b0fd9c2ee058b0967b17534457d7
     1.28.13: a22d234724b82101e1f17e95ab60e0e13c91a0fe17ad0890b3d92681cd551bfa
+    1.29.12: 1cf2c00bb4f5ee6df69678e95af8ba9a4d4b1050ddefb0ae9d84b5c6f6c0e817
+    1.30.8: e51d6a76fade0871a9143b64dc62a5ff44f369aa6cb4b04967d93798bf39d15b
 
-kubectl_download_url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubectl_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubectl" # noqa: yaml[line-length]
+kubectl_download_url: "https://cdn.dl.k8s.io/release/v{{ kubectl_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubectl" # noqa: yaml[line-length]
 kubectl_download_dest: /usr/bin/kubectl
 kubectl_binary_checksum: "{{ kubectl_checksums[download_artifact_goarch][kubectl_version] }}"
 

--- a/roles/kubelet/defaults/main.yml
+++ b/roles/kubelet/defaults/main.yml
@@ -30,6 +30,8 @@ kubelet_checksums:
     1.27.16: 1b390641b47c6f9265ed8d19b48a8aa334ac28c825ad7ee8201717a5d9e8b759
     1.28.4: db2a473b73c3754d4011590f2f0aa877657608499590c6b0f8b40bec96a3e9ba
     1.28.13: 9b9cc3a19551ade6f3d98ad3acf0a2b65a27ef575bd089f115f8bb80791f3900
+    1.29.12: 45475d908f6c44bfbf994fec91a4d5ceebf41d93c9f3867e687b2fa67b57b5b0
+    1.30.8: 7b5191dfed6a27faadefebdc4a3b602b9a76adfc58fd04c50307f1377eabc590
   arm64:
     1.19.16: 6e51cc1f16259b1016858f32bd48f44929b8330a26eb4da26929907872ab116f
     1.20.15: 8e3f08018fb66ee8b01d468779dc88608ce86f7a8bada85b5c5ddaae0280aeca
@@ -47,8 +49,10 @@ kubelet_checksums:
     1.27.16: 2d3cfefc64e1ff5f1e1b8bcba0589a4a9b247f7bcd43cb78645f346687cbbef3
     1.28.4: bf203989dd9b3987b8a0d2331dcce6319f834b57df810fafba5a4805d54823ac
     1.28.13: e1c222cfe7ba457e0b3dc54bbe6149231586e2031e4e0ffddd6e34836e80acea
+    1.29.12: 92237be83840bf8dd2318cb281ce309e907e0b665cac6b7629a5fa43a11ae606
+    1.30.8: fdda0047c8c6a59956db72c781705eb705018d00ba594afffdb15ef630f81e28
 
-kubelet_download_url: "https://storage.googleapis.com/kubernetes-release/release/v{{ kubelet_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubelet" # noqa: yaml[line-length]
+kubelet_download_url: "https://cdn.dl.k8s.io/release/v{{ kubelet_version }}/bin/{{ ansible_facts['system'] | lower }}/{{ download_artifact_goarch }}/kubelet" # noqa: yaml[line-length]
 kubelet_download_dest: /usr/bin/kubelet
 kubelet_binary_checksum: "{{ kubelet_checksums[download_artifact_goarch][kubelet_version] }}"
 

--- a/roles/kubernetes/templates/kubeadm.yaml.j2
+++ b/roles/kubernetes/templates/kubeadm.yaml.j2
@@ -67,8 +67,8 @@ dns:
 {% endif %}
 apiServer:
   extraArgs:
-    oidc-username-claim: email
 {% if kubernetes_oidc_issuer_url is defined %}
+    oidc-username-claim: "{{ kubernetes_oidc_username_claim }}"
     oidc-issuer-url: {{ kubernetes_oidc_issuer_url }}
     oidc-client-id: {{ kubernetes_oidc_client_id }}
 {% endif %}

--- a/zuul.d/jobs-focal.yaml
+++ b/zuul.d/jobs-focal.yaml
@@ -39,6 +39,20 @@
       tox_environment:
         KUBERNETES_VERSION: 1.28.13
 
+- job:
+    name: ansible-collection-kubernetes-molecule-focal-aio-1-29
+    parent: ansible-collection-kubernetes-molecule-focal-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.29.12
+
+- job:
+    name: ansible-collection-kubernetes-molecule-focal-aio-1-30
+    parent: ansible-collection-kubernetes-molecule-focal-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.30.8
+
 - project-template:
     name: ansible-collection-kubernetes-molecule-focal
     check:
@@ -46,8 +60,12 @@
         - ansible-collection-kubernetes-molecule-focal-aio-1-26
         - ansible-collection-kubernetes-molecule-focal-aio-1-27
         - ansible-collection-kubernetes-molecule-focal-aio-1-28
+        - ansible-collection-kubernetes-molecule-focal-aio-1-29
+        - ansible-collection-kubernetes-molecule-focal-aio-1-30
     gate:
       jobs:
         - ansible-collection-kubernetes-molecule-focal-aio-1-26
         - ansible-collection-kubernetes-molecule-focal-aio-1-27
         - ansible-collection-kubernetes-molecule-focal-aio-1-28
+        - ansible-collection-kubernetes-molecule-focal-aio-1-29
+        - ansible-collection-kubernetes-molecule-focal-aio-1-30

--- a/zuul.d/jobs-jammy.yaml
+++ b/zuul.d/jobs-jammy.yaml
@@ -36,6 +36,20 @@
       tox_environment:
         KUBERNETES_VERSION: 1.28.13
 
+- job:
+    name: ansible-collection-kubernetes-molecule-jammy-aio-1-29
+    parent: ansible-collection-kubernetes-molecule-jammy-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.29.12
+
+- job:
+    name: ansible-collection-kubernetes-molecule-jammy-aio-1-30
+    parent: ansible-collection-kubernetes-molecule-jammy-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.30.8
+
 - project-template:
     name: ansible-collection-kubernetes-molecule-jammy
     check:
@@ -43,8 +57,12 @@
         - ansible-collection-kubernetes-molecule-jammy-aio-1-26
         - ansible-collection-kubernetes-molecule-jammy-aio-1-27
         - ansible-collection-kubernetes-molecule-jammy-aio-1-28
+        - ansible-collection-kubernetes-molecule-jammy-aio-1-29
+        - ansible-collection-kubernetes-molecule-jammy-aio-1-30
     gate:
       jobs:
         - ansible-collection-kubernetes-molecule-jammy-aio-1-26
         - ansible-collection-kubernetes-molecule-jammy-aio-1-27
         - ansible-collection-kubernetes-molecule-jammy-aio-1-28
+        - ansible-collection-kubernetes-molecule-jammy-aio-1-29
+        - ansible-collection-kubernetes-molecule-jammy-aio-1-30

--- a/zuul.d/jobs-rockylinux9.yaml
+++ b/zuul.d/jobs-rockylinux9.yaml
@@ -40,6 +40,20 @@
       tox_environment:
         KUBERNETES_VERSION: 1.28.13
 
+- job:
+    name: ansible-collection-kubernetes-molecule-rockylinux9-aio-1-29
+    parent: ansible-collection-kubernetes-molecule-rockylinux9-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.29.12
+
+- job:
+    name: ansible-collection-kubernetes-molecule-rockylinux9-aio-1-30
+    parent: ansible-collection-kubernetes-molecule-rockylinux9-aio
+    vars:
+      tox_environment:
+        KUBERNETES_VERSION: 1.30.8
+
 - project-template:
     name: ansible-collection-kubernetes-molecule-rockylinux9
     check:
@@ -47,8 +61,12 @@
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-26
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-27
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-28
+        - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-29
+        - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-30
     gate:
       jobs:
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-26
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-27
         - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-28
+        - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-29
+        - ansible-collection-kubernetes-molecule-rockylinux9-aio-1-30


### PR DESCRIPTION
This effectively aims to add support and testing for currently supported
k8s versions, as 1.28 is going EOL in less then a month

Depends-On: https://github.com/vexxhost/ansible-collection-kubernetes/pull/149