### PR TITLE
Split image versions from URLs to make overriding easier

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -10,8 +10,9 @@ cert_manager_helm_values: {}
 
 cert_manager_node_selector: {}
 
-cert_manager_image_cli: quay.io/jetstack/cert-manager-ctl:v1.11.5
-cert_manager_image_controller: quay.io/jetstack/cert-manager-controller:v1.11.5
-cert_manager_image_cainjector: quay.io/jetstack/cert-manager-cainjector:v1.11.5
-cert_manager_image_webhook: quay.io/jetstack/cert-manager-webhook:v1.11.5
-cert_manager_image_acmesolver: quay.io/jetstack/cert-manager-acmesolver:v1.11.5
+cert_manager_image_tag: "v1.11.5"
+cert_manager_image_cli: "quay.io/jetstack/cert-manager-ctl:{{ cert_manager_image_tag }}"
+cert_manager_image_controller: "quay.io/jetstack/cert-manager-controller:{{ cert_manager_image_tag }}"
+cert_manager_image_cainjector: "quay.io/jetstack/cert-manager-cainjector:{{ cert_manager_image_tag }}"
+cert_manager_image_webhook: "quay.io/jetstack/cert-manager-webhook:{{ cert_manager_image_tag }}"
+cert_manager_image_acmesolver: "quay.io/jetstack/cert-manager-acmesolver:{{ cert_manager_image_tag }}"

--- a/roles/cilium/defaults/main.yml
+++ b/roles/cilium/defaults/main.yml
@@ -5,8 +5,9 @@ cilium_helm_chart_ref: /usr/local/src/cilium
 cilium_helm_release_namespace: kube-system
 cilium_helm_values: {}
 
-cilium_node_image: quay.io/cilium/cilium:v1.14.8@sha256:7fca3ba4b04af066e8b086b5c1a52e30f52db01ffc642e7db0a439514aed3ada
-cilium_operator_image: quay.io/cilium/operator-generic:v1.14.8@sha256:56d373c12483c09964a00a29246595917603a077a298aa90a98e4de32c86b7dc
+cilium_image_tag: "v1.14.8"
+cilium_node_image: quay.io/cilium/cilium:{{ cilium_image_tag }}
+cilium_operator_image: quay.io/cilium/operator-generic:{{ cilium_image_tag }}
 
 # With kubernetes_remove_kube_proxy set to 'true' configure Cilium to replace kube-proxy.
 # If set to 'false', Cilium will not replace kube-proxy.

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-haproxy_image: docker.io/library/haproxy:2.5
+haproxy_image_tag: "2.5"
+haproxy_image: "docker.io/library/haproxy:{{ haproxy_image_tag }}"
 
 haproxy_group: "{{ kubernetes_control_plane_group | default('controllers') }}"

--- a/roles/keepalived/defaults/main.yml
+++ b/roles/keepalived/defaults/main.yml
@@ -12,7 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-keepalived_image: us-docker.pkg.dev/vexxhost-infra/openstack/keepalived:2.0.19
+keepalived_image_tag: "2.0.19"
+keepalived_image: "us-docker.pkg.dev/vexxhost-infra/openstack/keepalived:{{ keepalived_image_tag }}"
 
 # NOTE(mnaser): These are some transitionary variables to make sure
 #               we don't break existing deployments.

--- a/roles/kube_vip/defaults/main.yml
+++ b/roles/kube_vip/defaults/main.yml
@@ -19,7 +19,8 @@ kube_vip_enabled: true
 kube_vip_control_plane_group: "{{ kubernetes_control_plane_group | default('controllers') }}"
 
 # Image to use for kube-vip
-kube_vip_image: ghcr.io/kube-vip/kube-vip:v0.6.4
+kube_vip_image_tag: "v0.6.4"
+kube_vip_image: "ghcr.io/kube-vip/kube-vip:{{ kube_vip_image_tag }}"
 
 # Interface to use for kube-vip
 kube_vip_interface: "{{ keepalived_interface | default(kubernetes_keepalived_interface) }}"


### PR DESCRIPTION
This PR splits the version out into a separate variable from image URLs. In doing so, when it is necessary to override image URLs to reference an offline registry, we can reference the image version(s) which match the version of this collection which we are pinning to.