### PR TITLE
fix: Ensure dbus is installed on Debian to set hostname

### DIFF
--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -125,6 +125,13 @@
     enabled: true
     state: started
 
+- name: Ensure availability of dbus on Debian
+  ansible.builtin.package:
+    name: dbus
+    state: present
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+
 - name: Configure short hostname
   ansible.builtin.hostname:
     name: "{{ kubelet_hostname }}"


### PR DESCRIPTION
https://github.com/vexxhost/ansible-collection-kubernetes/issues/158