### PR TITLE
fix: cert-manager custom volumemount for /etc/ssl/certs

### DIFF
--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -1,16 +1,5 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 cert_manager_helm_chart_path: "chart/"
 cert_manager_helm_chart_ref: /usr/local/src/cert-manager

--- a/roles/cert_manager/meta/main.yml
+++ b/roles/cert_manager/meta/main.yml
@@ -1,16 +1,5 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 galaxy_info:
   author: VEXXHOST, Inc.

--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -1,16 +1,5 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 - name: Deploy Helm chart
   run_once: true

--- a/roles/cert_manager/vars/main.yml
+++ b/roles/cert_manager/vars/main.yml
@@ -1,16 +1,5 @@
-# Copyright (c) 2023 VEXXHOST, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
+# Copyright (c) 2025 VEXXHOST, Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 _cert_manager_helm_values:
   installCRDs: true

--- a/roles/cert_manager/vars/main.yml
+++ b/roles/cert_manager/vars/main.yml
@@ -24,7 +24,7 @@ _cert_manager_helm_values:
   volumes:
     - name: etc-ssl-certs
       hostPath:
-        path: /etc/ssl/certs
+        path: "{{ '/etc/ssl/certs' if ansible_facts['os_family'] in ['Debian'] else '/etc/pki/ca-trust/extracted/openssl' }}"
   volumeMounts:
     - name: etc-ssl-certs
       mountPath: /etc/ssl/certs


### PR DESCRIPTION
Related: https://github.com/vexxhost/atmosphere/issues/184

Without this cert-manager "out of the box" is broken because it's left without any CA at all.

Previous workaround was to set:

```
cert_manager_helm_values:
  volumes: []
  volumeMounts: []
```