### PR TITLE
fix(kubelet): add retry logic to package installation tasks

### DIFF
--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -18,6 +18,10 @@
   ansible.builtin.dnf:
     name: coreutils
     allowerasing: true
+  register: _install_coreutils
+  retries: 5
+  delay: 10
+  until: _install_coreutils is not failed
   when:
     - ansible_facts['os_family'] == 'RedHat'
 
@@ -28,6 +32,10 @@
 - name: Install additional packages
   ansible.builtin.package:
     name: "{{ kubelet_package_dependencies }}"
+  register: _install_packages
+  retries: 5
+  delay: 10
+  until: _install_packages is not failed
 
 - name: Configure sysctl values
   ansible.posix.sysctl:
@@ -119,6 +127,10 @@
   ansible.builtin.package:
     name: dbus
     state: present
+  register: _install_dbus
+  retries: 5
+  delay: 10
+  until: _install_dbus is not failed
   when:
     - ansible_facts['os_family'] == 'Debian'
 


### PR DESCRIPTION
The kubelet role's package installation tasks (`Install coreutils`, `Install additional packages`, `Ensure availability of dbus`) lack retry logic. When kubelet runs concurrently with other components that hold the dpkg lock, the package tasks fail immediately with `rc:100` instead of retrying.

This adds `retries: 5` and `delay: 10` to all three package tasks, matching the pattern already used by other roles (e.g. `multipathd`, `iscsi`) in the [Atmosphere](https://github.com/vexxhost/atmosphere) project.

**Context:** vexxhost/atmosphere#3834 introduces a parallel deployment orchestrator where multiple components (ceph, kubernetes, multipathd, iscsi) run concurrently in Wave 0. Components with dpkg lock contention need retry logic to handle transient lock failures.