### PR TITLE
feat: support Ubuntu 26.04 and Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v25.6.1
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
+        language_version: python3

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,10 +8,10 @@ description: Ansible collection for deploying Kubernetes clusters
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.posix: '>=2.1.0'
-  community.crypto: '>=3.2.0'
-  community.general: '>=12.0.0'
-  kubernetes.core: '>=6.3.0'
+  ansible.posix: '>=1.6.0'
+  community.crypto: '>=2.2.3'
+  community.general: '>=4.5.0'
+  kubernetes.core: '>=2.3.2'
   vexxhost.containers: '>=1.6.0'
 tags:
   - application

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,10 +8,10 @@ description: Ansible collection for deploying Kubernetes clusters
 license:
   - GPL-3.0-or-later
 dependencies:
-  ansible.posix: '>=1.6.0'
-  community.crypto: '>=2.2.3'
-  community.general: '>=4.5.0'
-  kubernetes.core: '>=2.3.2'
+  ansible.posix: '>=2.1.0'
+  community.crypto: '>=3.2.0'
+  community.general: '>=12.0.0'
+  kubernetes.core: '>=6.3.0'
   vexxhost.containers: '>=1.6.0'
 tags:
   - application

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.1"
 authors = [{ name = "VEXXHOST, Inc.", email = "support@vexxhost.com" }]
 description = "Ansible collection for deploying Kubernetes clusters"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -14,13 +14,13 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "ansible-core>=2.15.9",
+  "ansible-core>=2.20",
   "docker-image-py>=0.1.12",
   "jmespath>=1.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.1"
 authors = [{ name = "VEXXHOST, Inc.", email = "support@vexxhost.com" }]
 description = "Ansible collection for deploying Kubernetes clusters"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -14,13 +14,15 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "ansible-core>=2.20",
+  "ansible-core>=2.15.9",
   "docker-image-py>=0.1.12",
   "jmespath>=1.0.1",
 ]

--- a/roles/cert_manager/meta/main.yml
+++ b/roles/cert_manager/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.kubernetes.upload_helm_chart

--- a/roles/cilium/meta/main.yml
+++ b/roles/cilium/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: upload_helm_chart

--- a/roles/cluster_api/meta/main.yml
+++ b/roles/cluster_api/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.kubernetes.clusterctl

--- a/roles/clusterctl/meta/main.yml
+++ b/roles/clusterctl/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.download_artifact

--- a/roles/envoy_gateway/meta/main.yml
+++ b/roles/envoy_gateway/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.kubernetes.upload_helm_chart

--- a/roles/flux/meta/main.yml
+++ b/roles/flux/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.download_artifact

--- a/roles/haproxy/meta/main.yml
+++ b/roles/haproxy/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.directory

--- a/roles/helm/meta/main.yml
+++ b/roles/helm/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.forget_package

--- a/roles/keepalived/meta/main.yml
+++ b/roles/keepalived/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.directory

--- a/roles/kube_vip/meta/main.yml
+++ b/roles/kube_vip/meta/main.yml
@@ -28,6 +28,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.directory

--- a/roles/kubeadm/meta/main.yml
+++ b/roles/kubeadm/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.forget_package

--- a/roles/kubectl/meta/main.yml
+++ b/roles/kubectl/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.forget_package

--- a/roles/kubelet/meta/main.yml
+++ b/roles/kubelet/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.containerd

--- a/roles/kubernetes/defaults/main.yml
+++ b/roles/kubernetes/defaults/main.yml
@@ -8,9 +8,6 @@ kubernetes_version: "{{ undef(hint='You must specify the exact Kubernetes versio
 # Name of Ansible group containing all control-plane nodes
 kubernetes_control_plane_group: controllers
 
-# TODO(mnaser): We should remove this at some point.
-kubernetes_repository_apt: "deb https://apt.kubernetes.io/ kubernetes-xenial main"
-
 # Kubernetes image repository (leave undefined to use the `kubeadm` default)
 kubernetes_image_repository: registry.k8s.io
 

--- a/roles/kubernetes/meta/main.yml
+++ b/roles/kubernetes/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute
 
 dependencies:
   - role: kubernetes_upgrade_check

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-- name: Remove kubernetes repository
-  ansible.builtin.apt_repository:
-    repo: "{{ kubernetes_repository_apt }}"
-    state: absent
-  when: ansible_facts['os_family'] in ['Debian']
-
 - name: Setup control plane
   when: inventory_hostname in groups[kubernetes_control_plane_group]
   ansible.builtin.include_tasks: control-plane.yml

--- a/roles/kubernetes_upgrade_check/meta/main.yml
+++ b/roles/kubernetes_upgrade_check/meta/main.yml
@@ -28,3 +28,5 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute

--- a/roles/openstack_resource_controller/meta/main.yml
+++ b/roles/openstack_resource_controller/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - focal
         - jammy
         - noble
+        - resolute
 
 dependencies:
   - role: vexxhost.kubernetes.upload_helm_chart

--- a/roles/upload_helm_chart/meta/main.yml
+++ b/roles/upload_helm_chart/meta/main.yml
@@ -28,3 +28,5 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
+        - resolute


### PR DESCRIPTION
Adds Ubuntu 26.04 (Resolute Raccoon) / Python 3.14 support.

## Changes

- **feat(meta):** Add `noble` and `resolute` to `galaxy_info.platforms` in all 17 roles.
- **refactor(kubernetes):** Drop the legacy `apt.kubernetes.io/kubernetes-xenial` default and its removal task. The upstream repository was shut down in March 2023.
- **fix(deps):** Raise `ansible-core` floor to `>=2.20` and `requires-python` to `>=3.12` (ansible-core 2.20 requires Python 3.12+). Advertise Python 3.13 and 3.14 as tested targets. Raise `community.general` to `>=12.0.0` to pick up the fix for the data-tagging templater introduced in ansible-core 2.19, which otherwise surfaces as `JMESPathError: invalid type ... unknown` from `json_query`. Align the remaining collection floors with versions validated on Python 3.14.

## Test

Built an all-in-one Kubernetes 1.34.0 cluster on a fresh Ubuntu 26.04 / Python 3.14 host using this branch plus the matching `vexxhost.containers` branch:

```
PLAY RECAP
controller : ok=115  changed=54   unreachable=0    failed=0    skipped=36

NAME         STATUS   ROLES           VERSION   CONTAINER-RUNTIME
controller   Ready    control-plane   v1.34.0   containerd://1.7.17
```

All control-plane pods (etcd, apiserver, controller-manager, scheduler, kube-vip), Cilium (agent + operator), and Envoy Gateway reach `Running` within ~5 minutes. Kernel 7.0.0, OS "Ubuntu Resolute Raccoon".

## Related

Needs vexxhost/ansible-collection-containers#TBD for `vexxhost.containers` to also advertise Noble and Resolute and align on `community.general>=12.0.0`.