### PR TITLE
feat: make cert-manager Gateway API ready

### DIFF
--- a/roles/cert_manager/vars/v1.15.yml
+++ b/roles/cert_manager/vars/v1.15.yml
@@ -5,6 +5,8 @@
 cert_manager_image_startupapicheck: "quay.io/jetstack/cert-manager-startupapicheck:{{ cert_manager_image_tag }}"
 
 _cert_manager_version_values:
+  extraArgs:
+    - --enable-gateway-api
   startupapicheck:
     image:
       repository: "{{ cert_manager_image_startupapicheck | vexxhost.kubernetes.docker_image('name') }}"


### PR DESCRIPTION
Merge only after Gateway API introduction in Atmosphere