### PR TITLE
ci: restrict privileged workflows to canonical repository

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   kubernetes:
+    if: ${{ github.repository == 'vexxhost/ansible-collection-kubernetes' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.repository == 'vexxhost/ansible-collection-kubernetes' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
- add repository guards to the Kubernetes bump and release-please jobs
- keep token-backed dependency bumping and Galaxy publishing limited to vexxhost/ansible-collection-kubernetes

## Testing
- `nix-shell -p yamllint --run 'yamllint .github/workflows/bump.yaml .github/workflows/release-please.yaml'` (passes with existing `on:` truthy warnings)
- `nix-shell -p actionlint --run 'actionlint .github/workflows/bump.yaml .github/workflows/release-please.yaml'`