### PR TITLE
ci: use github token for kubernetes bump PRs

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -20,15 +20,12 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          token: ${{ secrets.VEXXHOST_BOT_PAT }}
       - run: ./hack/bump/kubernetes.sh
         env:
           GH_TOKEN: ${{ github.token }}
       - uses: step-security/create-pull-request@50c103da2b9ca12cd5bc013fc6931051a5aa872b # v8.1.1
         with:
-          token: ${{ secrets.VEXXHOST_BOT_PAT }}
-          push-to-fork: vexxhost-bot/ansible-collection-kubernetes
+          token: ${{ github.token }}
           commit-message: "chore(deps): update kubernetes"
           signoff: true
           branch: bump/kubernetes


### PR DESCRIPTION
## Summary
- stop using `VEXXHOST_BOT_PAT` for Kubernetes bump PRs
- stop pushing bump branches through the `vexxhost-bot` fork
- rely on `GITHUB_TOKEN` now that pull_request workflows run for PRs created or updated by GitHub Actions

## Validation
- `nix-shell -p actionlint --run 'actionlint .github/workflows/bump.yaml'`
- `nix-shell -p yamllint --run 'yamllint .github/workflows/bump.yaml'` (passes with the existing GitHub Actions `on:` truthy warning)
- `git diff --check`