### PR TITLE
fix(kubelet): use boolean swap condition

### DIFF
--- a/roles/kubelet/tasks/main.yml
+++ b/roles/kubelet/tasks/main.yml
@@ -88,7 +88,7 @@
       changed_when: true
       ignore_errors: "{{ ansible_check_mode }}"
       when:
-        - kubelet_swapon.stdout
+        - kubelet_swapon.stdout | length > 0
 
     - name: Remove swapfile from /etc/fstab
       ansible.posix.mount:


### PR DESCRIPTION
## Classification

**Real fix**. This is an Ansible strict-conditional compatibility fix and is not Ubuntu 24.04-specific.

## Problem

The kubelet role uses `kubelet_swapon.stdout` directly as a `when` condition. Ansible 2.19 and later require conditionals to evaluate to a boolean, so a clean host without swap fails before kubelet deployment can complete.

## Change

Compare the command output length explicitly. Non-empty output runs `swapoff`; empty output skips it.

## Validation

- Reproduced with Ansible 2.21 during a clean Atmosphere AIO deployment.
- `git diff --check` passes.
- ansible-lint parsed the changed task successfully; it reports three unrelated pre-existing role variable-prefix violations.
- The collection unit suite cannot be invoked directly from an arbitrary worktree without its collection-path test harness; live role validation is in progress on the reproducing host.

Signed-off-by: Rico Lin <rlin@vexxhost.com>